### PR TITLE
Refactor: Convert bot from userbot to standard bot

### DIFF
--- a/config.py
+++ b/config.py
@@ -12,8 +12,6 @@ START_TIME = time.time()
 
 #Preferences os >> env >> default
 
-API_KEY = os.environ.get('API_ID') or os.getenv('API_ID') or "API_KEY"
-API_HASH = os.environ.get('API_HASH') or os.getenv("API_HASH")   or "API_HASH"
 BOT_TOKEN = os.environ.get('BOT_TOKEN ') or os.getenv("BOT_TOKEN") or   "BOT_TOKEN"
 ADMINS=[]
 ADMINS = os.environ.get('ADMIN_IDS') or os.getenv("ADMIN_IDS") or "123456789"

--- a/run.py
+++ b/run.py
@@ -61,8 +61,6 @@ logger = logging.getLogger(__name__)
 advAiBot = pyrogram.Client(
     "AdvChatGptBotV2", 
     bot_token=config.BOT_TOKEN, 
-    api_id=config.API_KEY, 
-    api_hash=config.API_HASH,
     workdir="sessions"
 )
 


### PR DESCRIPTION
Removes api_id and api_hash from client initialization and configuration. The bot will now authenticate using only the BOT_TOKEN, as is standard for Telegram bots.

This change addresses the issue of unnecessary user-specific credentials being required and simplifies the bot's authentication mechanism. The bot will now operate under the standard Telegram Bot API, and any functionality that relied on user-level permissions (e.g., initiating chats, broader access to chat history) will be limited accordingly.